### PR TITLE
Issue #7: Add date and time in the beginning of the checkout process

### DIFF
--- a/checkout.py
+++ b/checkout.py
@@ -27,7 +27,10 @@ print(items)
 
 def create_custom_receipt():
     dashes = "--------------------------------"
-    return dashes + "\n" + " "*9 + GROCERY_STORE_NAME + "\n\n" + DATE_TIME_FORMAT + "\n" + dashes
+    return dashes + "\n"\
+           + " "*9 + GROCERY_STORE_NAME + "\n\n"\
+           + DATE_TIME_FORMAT + "\n" \
+           + dashes
 
 
 receipt = create_custom_receipt()

--- a/checkout.py
+++ b/checkout.py
@@ -8,9 +8,10 @@ from datetime import datetime
 from validation import is_clerk_input_valid
 
 GROCERY_STORE_NAME = "Shop N Bag"
-date_and_time = datetime.now()
-DATE_TIME_FORMAT = date_and_time.strftime("%B %d %Y %H:%M:%S") # Example: August 29 2021 13:14:55
+DATE_TIME_FORMAT = "%B %d %Y %H:%M:%S"  # Example: August 29 2021 13:14:55
+
 items = []
+date_time = datetime.now()
 
 while True:
 
@@ -25,11 +26,15 @@ while True:
 
 print(items)
 
+
 def create_custom_receipt():
+
     dashes = "--------------------------------"
-    return dashes + "\n"\
-           + " "*9 + GROCERY_STORE_NAME + "\n\n"\
-           + DATE_TIME_FORMAT + "\n" \
+    formatted_date_and_time = date_time.strftime(DATE_TIME_FORMAT)
+
+    return dashes + "\n" \
+           + " " * 9 + GROCERY_STORE_NAME + "\n\n" \
+           + formatted_date_and_time + "\n" \
            + dashes
 
 

--- a/checkout.py
+++ b/checkout.py
@@ -7,10 +7,10 @@ Created on Fri Aug 13 11:35:57 2021
 from datetime import datetime
 from validation import is_clerk_input_valid
 
-items = []
 GROCERY_STORE_NAME = "Shop N Bag"
 date_and_time = datetime.now()
 DATE_TIME_FORMAT = date_and_time.strftime("%B %d %Y %H:%M:%S") # Example: August 29 2021 13:14:55
+items = []
 
 while True:
 

--- a/checkout.py
+++ b/checkout.py
@@ -3,11 +3,15 @@
 Created on Fri Aug 13 11:35:57 2021
 
 @author: vjham
+
 """
+from datetime import datetime
 from validation import is_clerk_input_valid
 
 items = []
 GROCERY_STORE_NAME = "Shop N Bag"
+DATE_AND_TIME = datetime.now()
+DATE_TIME_FORMAT = DATE_AND_TIME.strftime("%B %d %Y %H:%M:%S")
 
 while True:
 
@@ -24,7 +28,7 @@ print (items)
 
 def create_custom_receipt():
     dashes = "--------------------------------"
-    return dashes + "\n" + GROCERY_STORE_NAME + "\n" + dashes
+    return dashes + "\n" + " "*9 + GROCERY_STORE_NAME + "\n\n" + DATE_TIME_FORMAT + "\n" + dashes
 
 
 receipt = create_custom_receipt()

--- a/checkout.py
+++ b/checkout.py
@@ -3,7 +3,6 @@
 Created on Fri Aug 13 11:35:57 2021
 
 @author: vjham
-
 """
 from datetime import datetime
 from validation import is_clerk_input_valid

--- a/checkout.py
+++ b/checkout.py
@@ -10,7 +10,7 @@ from validation import is_clerk_input_valid
 items = []
 GROCERY_STORE_NAME = "Shop N Bag"
 date_and_time = datetime.now()
-DATE_TIME_FORMAT = date_and_time.strftime("%B %d %Y %H:%M:%S")
+DATE_TIME_FORMAT = date_and_time.strftime("%B %d %Y %H:%M:%S") # Example: August 29 2021 13:14:55
 
 while True:
 

--- a/checkout.py
+++ b/checkout.py
@@ -22,9 +22,9 @@ while True:
         else:
             items.append(item_id_input)
     else:
-        print ("That is an invalid product identifier. You are fired!")
+        print("That is an invalid product identifier. You are fired!")
 
-print (items)
+print(items)
 
 def create_custom_receipt():
     dashes = "--------------------------------"

--- a/checkout.py
+++ b/checkout.py
@@ -9,8 +9,8 @@ from validation import is_clerk_input_valid
 
 items = []
 GROCERY_STORE_NAME = "Shop N Bag"
-DATE_AND_TIME = datetime.now()
-DATE_TIME_FORMAT = DATE_AND_TIME.strftime("%B %d %Y %H:%M:%S")
+date_and_time = datetime.now()
+DATE_TIME_FORMAT = date_and_time.strftime("%B %d %Y %H:%M:%S")
 
 while True:
 


### PR DESCRIPTION
#7 
Adding an example of a real grocery shop receipt:
<img width="157" alt="Screenshot 2021-08-29 at 22 18 17" src="https://user-images.githubusercontent.com/59181148/131265755-5270e0fd-9a33-4eeb-ac86-3147830dec73.png">

Adding the output of our current receipt:
<img width="271" alt="Screenshot 2021-08-29 at 23 00 37" src="https://user-images.githubusercontent.com/59181148/131266700-84136a46-df61-4319-bdad-3fee454873fa.png">

